### PR TITLE
Publish slsk-client to npm via CI with OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,11 @@ on:
 
 jobs:
   release:
+    name: Publish to npm
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
+      id-token: write # required for npm provenance
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,8 +26,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://npm.pkg.github.com
-          scope: '@${{ github.repository_owner }}'
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -37,32 +37,30 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Release to GitHub Packages
+      - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           PKG_NAME=$(node -p "require('./package.json').name")
-          OWNER="${{ github.repository_owner }}"
-          EXPECTED_NAME="@${OWNER}/slsk-client"
-
-          if [ "$PKG_NAME" != "$EXPECTED_NAME" ] && [ -n "$OWNER" ]; then
-            echo "Adjusting package name to match repository owner: $EXPECTED_NAME"
-            npm pkg set name="$EXPECTED_NAME"
-            PKG_NAME="$EXPECTED_NAME"
-          fi
 
           echo "Package: $PKG_NAME"
           echo "Version: $VERSION"
 
-          # Check if this version is already published on GitHub Packages
-          if npm view "${PKG_NAME}@${VERSION}" version --registry=https://npm.pkg.github.com >/dev/null 2>&1; then
-            echo "Version ${VERSION} of ${PKG_NAME} is already published on GitHub Packages. Skipping publish."
+          # Check if this version is already published on npm
+          if npm view "${PKG_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "Version ${VERSION} of ${PKG_NAME} is already published on npm. Skipping publish."
           else
-            echo "Publishing ${PKG_NAME}@${VERSION} to GitHub Packages..."
-            npm publish --access public
-            echo "Successfully published ${PKG_NAME}@${VERSION} to GitHub Packages."
+            echo "Publishing ${PKG_NAME}@${VERSION} to npm..."
+            if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
+              echo "Using NPM_TOKEN from repository secrets."
+              export NODE_AUTH_TOKEN="${{ secrets.NPM_TOKEN }}"
+            else
+              echo "Using npm Trusted Publishing (OIDC)."
+            fi
+
+            npm publish --access public --provenance
+            echo "Successfully published ${PKG_NAME}@${VERSION} to npm."
 
             TAG="v${VERSION}"
             if ! gh release view "$TAG" >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -18,23 +18,16 @@ A modern NodeJS client for the Soulseek peer-to-peer network, written in TypeScr
 
 ## Installation
 
-Install from GitHub Packages:
-
 ```sh
-npm install @f-hj/slsk-client
+npm install slsk-client
 ```
-
-> **Note**: To install packages from GitHub Packages, configure `@f-hj` in your `~/.npmrc` or project `.npmrc`:
-> ```ini
-> @f-hj:registry=https://npm.pkg.github.com
-> ```
 
 ## Getting Started
 
 You must already have a Soulseek account before using this module.
 
 ```ts
-import { SlskClient, FileAttribute } from '@f-hj/slsk-client'
+import { SlskClient, FileAttribute } from 'slsk-client'
 
 const client = new SlskClient()
 await client.login('myUsername', 'myPassword')
@@ -98,7 +91,7 @@ await client.download({ ...result, signal: AbortSignal.timeout(30000) })
 Files can be shared using built-in or custom share providers:
 
 ```ts
-import { SlskClient, fsShareProvider, memoryShareProvider } from '@f-hj/slsk-client'
+import { SlskClient, fsShareProvider, memoryShareProvider } from 'slsk-client'
 
 const client = new SlskClient({
   shares: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@f-hj/slsk-client",
+  "name": "slsk-client",
   "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@f-hj/slsk-client",
+      "name": "slsk-client",
       "version": "2.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f-hj/slsk-client",
+  "name": "slsk-client",
   "version": "2.0.1",
   "description": "Soulseek NodeJS client",
   "main": "dist/index.js",
@@ -7,10 +7,6 @@
   "files": [
     "dist"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com",
-    "access": "public"
-  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary
- Configures CI release workflow (`.github/workflows/release.yml`) to publish exclusively to npmjs.com as `slsk-client`.
- Supports npm Trusted Publishing (OIDC) with provenance via `id-token: write` permission, with fallback to `NPM_TOKEN` if present in repository secrets.
- Checks if the version is already published on npm before publishing (idempotent on push to `master`).
- Restores package name to `slsk-client` in `package.json` and updates `README.md` to reference `npm install slsk-client`.

## Verification
- `npm test` passes (187 unit tests passing)
- `npm run build` succeeds