### PR TITLE
fix(ci): fix npm OIDC trusted publishing (Node 24 & clean npmrc)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -54,7 +53,7 @@ jobs:
             echo "Publishing ${PKG_NAME}@${VERSION} to npm..."
             if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
               echo "Using NPM_TOKEN from repository secrets."
-              export NODE_AUTH_TOKEN="${{ secrets.NPM_TOKEN }}"
+              npm config set //registry.npmjs.org/:_authToken "${{ secrets.NPM_TOKEN }}"
             else
               echo "Using npm Trusted Publishing (OIDC)."
             fi


### PR DESCRIPTION
## Summary
- Upgrades Node to 24 in `.github/workflows/release.yml`. npm Trusted Publishing (OIDC) requires npm CLI 11.5.1+ (Node 24 ships with npm 11+; Node 22 ships with npm 10 which fails OIDC token exchange with E404).
- Removes `registry-url` from `actions/setup-node`. When specified without a token, `setup-node` creates an `.npmrc` with an empty `_authToken`, which causes npm to skip the OIDC exchange and fail authentication with E404.

## Verification
- CI workflow triggers and checks pass